### PR TITLE
make image (much) smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1.17.6
+FROM golang:1.17.6 as build
 ARG COMMIT="latest"
-
-RUN mkdir -p /heartbeat/config
-ADD . /heartbeat
 WORKDIR /heartbeat
+RUN mkdir -p /heartbeat/config
+COPY . .
 
 ENV PATH "${PATH}:${GOPATH}/bin"
 RUN make deps build
 
-CMD /heartbeat/heartbeat
+FROM gcr.io/distroless/base-debian11
+COPY --from=build /heartbeat/heartbeat /heartbeat/heartbeat
+COPY --from=build /heartbeat/www /heartbeat/www
+WORKDIR /heartbeat
+ENTRYPOINT [ "/heartbeat/heartbeat" ]

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,7 @@ build: generate
 
 deps:
 	go install github.com/valyala/quicktemplate/qtc
-	go get -u github.com/ferluci/fast-realip
-	go get -u github.com/go-redis/redis/v8
-	go get -u github.com/joho/godotenv
-	go get -u github.com/nitishm/go-rejson/v4
-	go get -u github.com/valyala/fasthttp
-	go get -u github.com/valyala/quicktemplate
-	go get -u golang.org/x/text/language
-	go get -u golang.org/x/text/message
+	go get -u ./...
 
 docker-build:
 	@docker build --build-arg COMMIT=${TAG} -t ${IMG} .


### PR DESCRIPTION
This commit just makes use of docker multi-stage builds. Since Go links *everything* statically, and we only need `libc` at runtime, and not the plethora of tools in the Go base image, we run from a distroless image with just the binary and the static assets.

This brings down the image size by ~62.5% (1.13GiB --> 30.2MiB)